### PR TITLE
feat(headers): add custom header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ let resp = curl_rest::Curl::default()
     .get()
     .header(curl_rest::Header::Authorization("Bearer token".into()))
     .header(curl_rest::Header::Accept("application/json".into()))
+    .header(curl_rest::Header::Custom(
+        "X-Request-Id".into(),
+        "req-12345".into(),
+    ))
     .send("https://example.com/private")?;
 # Ok::<(), curl_rest::Error>(())
 ```


### PR DESCRIPTION
Introduce Header::Custom for non-standard names with RFC 9110 token validation. Validate custom header names and newline-free values, update Content-Type detection, and expand tests and docs to cover custom headers.