### PR TITLE
feat: add default user-agent constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ println!("Status: {}", resp.status);
 println!("{}", String::from_utf8_lossy(&resp.body));
 ```
 
+### Default User-Agent
+
+```rust
+let resp = curl_rest::Curl::with_user_agent("my-app/1.0")
+    .get()
+    .header(curl_rest::Header::Accept("application/json".into()))
+    .send("https://example.com/api/users")?;
+# Ok::<(), curl_rest::Error>(())
+```
+
+If you set a `User-Agent` header explicitly, it overrides the default.
+
 ### Headers
 
 ```rust


### PR DESCRIPTION
Add Curl::with_user_agent to set a default User-Agent for the builder. Apply the default header only when no User-Agent is already present. Add detection helper and tests, and document usage in the README.