### PR TITLE
feat: add support for setting max redirects

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,6 +635,7 @@ impl<'a> Client<'a> {
         let mut easy = Easy2::new(Collector::new());
         self.method.apply(&mut easy)?;
         if self.max_redirects >= 0 {
+            easy.follow_location(true)?;
             easy.max_redirections(self.max_redirects as u32)?;
         }
         let mut list = List::new();


### PR DESCRIPTION
## Summary

Add support for setting redirects. See #12 

## Changes

- Add a new function called max redirects.

## Testing

- [ ] Tests added or updated
- [ ] `cargo test`
- [ ] `cargo fmt`
- [ ] `cargo clippy`

## Checklist

- [x] Docs updated (if needed)
- [ ] Breaking change (if yes, explain below)
- [ ] Changelog updated (if needed)

## Breaking Change Details

Describe any breaking changes and migration guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP client gains configurable redirect limits via a new builder option. Default limit is 1; set a negative value to allow unlimited redirects. Redirect following is enforced when configured.
* **Documentation**
  * Added usage notes clarifying semantics of the redirect setting and how to configure it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->