### PR TITLE
add PartialEq to header

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ pub enum Error {
 }
 
 /// Common HTTP headers supported by the client, plus `Custom` for non-standard names.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Header<'a> {
     /// Authorization header, e.g. "Bearer &lt;token&gt;".
     Authorization(Cow<'a, str>),
@@ -1074,5 +1074,17 @@ mod tests {
     #[test]
     fn status_code_default_is_ok() {
         assert_eq!(StatusCode::default(), StatusCode::Ok);
+    }
+
+    #[test]
+    fn headers_comparission() {
+        let mut headers: Vec<Header> = Vec::new();
+        headers.push(Header::AcceptEncoding(Cow::Borrowed("br")));
+
+        assert!(
+            headers
+                .iter()
+                .any(|header| header == &Header::AcceptEncoding(Cow::Borrowed("br")))
+        )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1077,7 +1077,7 @@ mod tests {
     }
 
     #[test]
-    fn headers_comparission() {
+    fn headers_comparison() {
         let mut headers: Vec<Header> = Vec::new();
         headers.push(Header::AcceptEncoding(Cow::Borrowed("br")));
 


### PR DESCRIPTION
## Summary

This allows for headers to be compared.

## Changes
-  Add PartialEq trait

## Testing

- [x] Tests added or updated
- [x] `cargo test`
- [x] `cargo fmt`
- [x] `cargo clippy`

## Checklist

- [x] Docs updated (if needed)
- [x] Breaking change (if yes, explain below)
- [x] Changelog updated (if needed)

## Breaking Change Details

NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headers now support equality comparison, allowing direct validation and comparison between header variants in the public API.

* **Tests**
  * New unit test added to verify header equality behaviour, improving confidence in header comparisons for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->